### PR TITLE
Inline lets before trigger selection

### DIFF
--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -15480,6 +15480,15 @@ namespace Microsoft.Dafny {
       return s.Substitute(expr);
     }
 
+    public static Expression InlineLet(LetExpr letExpr) {
+      Contract.Requires(letExpr.LHSs.All(p => p.Var != null));
+      var substMap = new Dictionary<IVariable, Expression>();
+      for (var i = 0; i < letExpr.LHSs.Count; i++) {
+        substMap.Add(letExpr.LHSs[i].Var, letExpr.RHSs[i]);
+      }
+      return Translator.Substitute(letExpr.Body, null, substMap);
+    }
+
     public class FunctionCallSubstituter : Substituter
     {
       public readonly Function A, B;

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -2441,7 +2441,7 @@ namespace Microsoft.Dafny {
         if (prev != null) {
           Formals.AddRange(prev.Formals);
           foreach (var e in prev.ReplacementExprs) {
-            ReplacementExprs.Add(translator.Substitute(e, null, substMap));
+            ReplacementExprs.Add(Translator.Substitute(e, null, substMap));
           }
           foreach (var rf in prev.ReplacementFormals) {
             if (rf != formal) {
@@ -2449,7 +2449,7 @@ namespace Microsoft.Dafny {
             }
           }
           foreach (var entry in prev.SubstMap) {
-            SubstMap.Add(entry.Key, translator.Substitute(entry.Value, null, substMap));
+            SubstMap.Add(entry.Key, Translator.Substitute(entry.Value, null, substMap));
           }
         }
         if (formal is Formal) {
@@ -11745,7 +11745,7 @@ namespace Microsoft.Dafny {
         FTVs = template.FTVs;
         FTV_Types = template.FTV_Types.ConvertAll(t => Resolver.SubstType(t, typeMap));
         FVs = template.FVs;
-        FV_Exprs = template.FV_Exprs.ConvertAll(e => translator.Substitute(e, null, substMap, typeMap));
+        FV_Exprs = template.FV_Exprs.ConvertAll(e => Translator.Substitute(e, null, substMap, typeMap));
         UsesHeap = template.UsesHeap;
         UsesOldHeap = template.UsesOldHeap;
         ThisType = template.ThisType;
@@ -12527,7 +12527,7 @@ namespace Microsoft.Dafny {
         for (int i = 0; i < e.LHSs.Count; i++) {
           translator.AddCasePatternVarSubstitutions(e.LHSs[i], TrExpr(e.RHSs[i]), substMap);
         }
-        return translator.Substitute(e.Body, null, substMap);
+        return Translator.Substitute(e.Body, null, substMap);
       }
 
       public Expr MaybeLit(Expr expr, Bpl.Type type) {
@@ -13460,7 +13460,7 @@ namespace Microsoft.Dafny {
             var bv = e.BoundVars[0];
             Bpl.Expr typeAntecedent = translator.MkIsBox(new Bpl.IdentifierExpr(expr.tok, yVar), bv.Type);
             var yUnboxed = translator.UnboxIfBoxed(new Bpl.IdentifierExpr(expr.tok, yVar), bv.Type);
-            var range = translator.Substitute(e.Range, bv, new BoogieWrapper(yUnboxed, bv.Type));
+            var range = Translator.Substitute(e.Range, bv, new BoogieWrapper(yUnboxed, bv.Type));
             lbody = BplAnd(typeAntecedent, TrExpr(range));
           } else {
             // lambda y: BoxType :: (exists xs :: CorrectType(xs) && R && y==Box(T))
@@ -13496,9 +13496,9 @@ namespace Microsoft.Dafny {
           Dictionary<IVariable, Expression> subst = new Dictionary<IVariable,Expression>();
           subst.Add(e.BoundVars[0], new BoogieWrapper(unboxy,e.BoundVars[0].Type));
 
-          var ebody = BplAnd(typeAntecedent ?? Bpl.Expr.True, TrExpr(translator.Substitute(e.Range, null, subst)));
+          var ebody = BplAnd(typeAntecedent ?? Bpl.Expr.True, TrExpr(Translator.Substitute(e.Range, null, subst)));
           Bpl.Expr l1 = new Bpl.LambdaExpr(e.tok, new List<TypeVariable>(), new List<Variable> { yVar }, kv, ebody);
-          ebody = TrExpr(translator.Substitute(e.Term, null, subst));
+          ebody = TrExpr(Translator.Substitute(e.Term, null, subst));
           Bpl.Expr l2 = new Bpl.LambdaExpr(e.tok, new List<TypeVariable>(), new List<Variable> { yVar }, kv, BoxIfNecessary(expr.tok, ebody, e.Term.Type));
 
           bool finite = e.Finite;
@@ -13594,12 +13594,12 @@ namespace Microsoft.Dafny {
         var ly = BplBoundVar(varNameGen.FreshId("#ly#"), predef.LayerType, lvars);
         et = et.WithLayer(ly);
 
-        var ebody = et.TrExpr(translator.Substitute(e.Body, null, subst));
+        var ebody = et.TrExpr(Translator.Substitute(e.Body, null, subst));
         ebody = translator.BoxIfUnboxed(ebody, e.Body.Type);
 
         Bpl.Expr reqbody = Bpl.Expr.True;
         if (e.Range != null) {
-          reqbody = et.TrExpr(translator.Substitute(e.Range, null, subst));
+          reqbody = et.TrExpr(Translator.Substitute(e.Range, null, subst));
         }
         if (e.OneShot) {
           reqbody = BplAnd(reqbody, Bpl.Expr.Eq(HeapExpr, heap));
@@ -13653,7 +13653,7 @@ namespace Microsoft.Dafny {
             }
             argIndex++;
           }
-          var c = translator.Substitute(mc.Body, null, substMap);
+          var c = Translator.Substitute(mc.Body, null, substMap);
           if (r == null) {
             r = c;
           } else {
@@ -13896,7 +13896,7 @@ namespace Microsoft.Dafny {
           if (compr.TermIsSimple) {
             // CorrectType(elmt) && R[xs := elmt]
             Bpl.Expr typeAntecedent = translator.GetWhereClause(compr.tok, elmt, compr.BoundVars[0].Type, this, NOALLOC) ?? Bpl.Expr.True;
-            var range = translator.Substitute(compr.Range, compr.BoundVars[0], new BoogieWrapper(elmt, compr.BoundVars[0].Type));
+            var range = Translator.Substitute(compr.Range, compr.BoundVars[0], new BoogieWrapper(elmt, compr.BoundVars[0].Type));
             return BplAnd(typeAntecedent, TrExpr(range));
           } else {
             // exists xs :: CorrectType(xs) && R && elmt==T
@@ -15462,7 +15462,7 @@ namespace Microsoft.Dafny {
     /// <summary>
     /// Returns an expression like "expr", but where free occurrences of "v" have been replaced by "e".
     /// </summary>
-    public Expression Substitute(Expression expr, IVariable v, Expression e) {
+    public static Expression Substitute(Expression expr, IVariable v, Expression e) {
       Contract.Requires(expr != null);
       Contract.Requires(v != null);
       Contract.Requires(e != null);
@@ -15472,7 +15472,7 @@ namespace Microsoft.Dafny {
       return Substitute(expr, null, substMap);
     }
 
-    public Expression Substitute(Expression expr, Expression receiverReplacement, Dictionary<IVariable, Expression/*!*/>/*!*/ substMap, Dictionary<TypeParameter, Type>/*?*/ typeMap = null) {
+    public static Expression Substitute(Expression expr, Expression receiverReplacement, Dictionary<IVariable, Expression/*!*/>/*!*/ substMap, Dictionary<TypeParameter, Type>/*?*/ typeMap = null) {
       Contract.Requires(expr != null);
       Contract.Requires(cce.NonNullDictionaryAndValues(substMap));
       Contract.Ensures(Contract.Result<Expression>() != null);

--- a/Source/Dafny/Triggers/TriggersCollector.cs
+++ b/Source/Dafny/Triggers/TriggersCollector.cs
@@ -199,11 +199,7 @@ namespace Microsoft.Dafny.Triggers {
         var le = (LetExpr)expr;
         if (le.LHSs.All(p => p.Var != null)) {
           // Inline the let expression before doing trigger selection.
-          var substMap = new Dictionary<IVariable, Expression>();
-          for (var i = 0; i < le.LHSs.Count; i++) {
-            substMap.Add(le.LHSs[i].Var, le.RHSs[i]);
-          }
-          annotation = Annotate(Translator.Substitute(le.Body, null, substMap));
+          annotation = Annotate(Translator.InlineLet(le));
         }
       }
       

--- a/Source/Dafny/Triggers/TriggersCollector.cs
+++ b/Source/Dafny/Triggers/TriggersCollector.cs
@@ -193,34 +193,45 @@ namespace Microsoft.Dafny.Triggers {
         return cached;
       }
 
-      expr.SubExpressions.Iter(e => Annotate(e));
+      TriggerAnnotation annotation = null; // TODO: Using ApplySuffix fixes the unresolved members problem in GenericSort
 
-      TriggerAnnotation annotation; // TODO: Using ApplySuffix fixes the unresolved members problem in GenericSort
-      if (IsPotentialTriggerCandidate(expr)) { 
-        annotation = AnnotatePotentialCandidate(expr);
-      } else if (expr is QuantifierExpr) {
-        annotation = AnnotateQuantifier((QuantifierExpr)expr);
-      } else if (expr is LetExpr) {
-        annotation = AnnotateLetExpr((LetExpr)expr);
-      } else if (expr is IdentifierExpr) {
-        annotation = AnnotateIdentifier((IdentifierExpr)expr);
-      } else if (expr is ApplySuffix) {
-        annotation = AnnotateApplySuffix((ApplySuffix)expr);
-      } else if (expr is MatchExpr) {
-        annotation = AnnotateMatchExpr((MatchExpr)expr);
-      } else if (expr is ComprehensionExpr) {
-        annotation = AnnotateComprehensionExpr((ComprehensionExpr)expr);
-      } else if (expr is ConcreteSyntaxExpression ||
-                 expr is LiteralExpr ||
-                 expr is OldExpr ||
-                 expr is ThisExpr ||
-                 expr is BoxingCastExpr ||
-                 expr is MultiSetFormingExpr) {
-        annotation = AnnotateOther(expr, false);
-      } else {
-        annotation = AnnotateOther(expr, true);
+      if (expr is LetExpr) {
+        var le = (LetExpr)expr;
+        if (le.LHSs.Count == 1 && le.LHSs[0].Var != null) {
+          // Inline the let expression before doing trigger selection.
+          annotation = Annotate(Translator.Substitute(le.Body, le.LHSs[0].Var, le.RHSs[0]));
+        }
       }
+      
+      if (annotation == null) {
+        expr.SubExpressions.Iter(e => Annotate(e));
 
+        if (IsPotentialTriggerCandidate(expr)) {
+          annotation = AnnotatePotentialCandidate(expr);
+        } else if (expr is QuantifierExpr) {
+          annotation = AnnotateQuantifier((QuantifierExpr)expr);
+        } else if (expr is LetExpr) {
+          annotation = AnnotateLetExpr((LetExpr)expr);
+        } else if (expr is IdentifierExpr) {
+          annotation = AnnotateIdentifier((IdentifierExpr)expr);
+        } else if (expr is ApplySuffix) {
+          annotation = AnnotateApplySuffix((ApplySuffix)expr);
+        } else if (expr is MatchExpr) {
+          annotation = AnnotateMatchExpr((MatchExpr)expr);
+        } else if (expr is ComprehensionExpr) {
+          annotation = AnnotateComprehensionExpr((ComprehensionExpr)expr);
+        } else if (expr is ConcreteSyntaxExpression ||
+                   expr is LiteralExpr ||
+                   expr is OldExpr ||
+                   expr is ThisExpr ||
+                   expr is BoxingCastExpr ||
+                   expr is MultiSetFormingExpr) {
+          annotation = AnnotateOther(expr, false);
+        } else {
+          annotation = AnnotateOther(expr, true);
+        }
+      }
+    
       TriggerUtils.DebugTriggers("{0} ({1})\n{2}", Printer.ExprToString(expr), expr.GetType(), annotation);
       cache.annotations[expr] = annotation;
       return annotation;

--- a/Source/Dafny/Triggers/TriggersCollector.cs
+++ b/Source/Dafny/Triggers/TriggersCollector.cs
@@ -197,9 +197,13 @@ namespace Microsoft.Dafny.Triggers {
 
       if (expr is LetExpr) {
         var le = (LetExpr)expr;
-        if (le.LHSs.Count == 1 && le.LHSs[0].Var != null) {
+        if (le.LHSs.All(p => p.Var != null)) {
           // Inline the let expression before doing trigger selection.
-          annotation = Annotate(Translator.Substitute(le.Body, le.LHSs[0].Var, le.RHSs[0]));
+          var substMap = new Dictionary<IVariable, Expression>();
+          for (var i = 0; i < le.LHSs.Count; i++) {
+            substMap.Add(le.LHSs[i].Var, le.RHSs[i]);
+          }
+          annotation = Annotate(Translator.Substitute(le.Body, null, substMap));
         }
       }
       

--- a/Test/dafny0/Modules1.dfy
+++ b/Test/dafny0/Modules1.dfy
@@ -125,7 +125,7 @@ abstract module Regression {
     predicate p<c,d>(m: map<c,d>)
 
     lemma m<a,b>(m: map<a,b>)
-      ensures exists m {:nowarn} :: p(var m : map<a,b> := m; m) // WISH: Zeta-expanding the let binding would provide a good trigger
+      ensures exists m :: p(var m : map<a,b> := m; m)
   }
 
   abstract module B

--- a/Test/triggers/let-expressions.dfy
+++ b/Test/triggers/let-expressions.dfy
@@ -3,5 +3,6 @@
 
 predicate Foo(s: seq<int>)
 {
-    forall i :: 0 <= i < |s| ==> var j := i; s[j] > 0
+    && (forall i :: 0 <= i < |s| ==> var j := i; s[j] > 0)
+    && (forall i :: 0 <= i < |s| ==> var j, k := i, i; s[k] > 0)
 }

--- a/Test/triggers/let-expressions.dfy
+++ b/Test/triggers/let-expressions.dfy
@@ -1,0 +1,7 @@
+// RUN: %dafny /compile:0 /print:"%t.print" /dprint:"%t.dprint" /autoTriggers:1 /printTooltips "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+predicate Foo(s: seq<int>)
+{
+    forall i :: 0 <= i < |s| ==> var j := i; s[j] > 0
+}

--- a/Test/triggers/let-expressions.dfy
+++ b/Test/triggers/let-expressions.dfy
@@ -5,4 +5,6 @@ predicate Foo(s: seq<int>)
 {
     && (forall i :: 0 <= i < |s| ==> var j := i; s[j] > 0)
     && (forall i :: 0 <= i < |s| ==> var j, k := i, i; s[k] > 0)
+    && (forall i :: 0 <= i < |s|-1 ==> s[i] == s[i+1])
+    && (forall i :: 0 <= i < |s|-1 ==> s[i] == var j := i+1; s[j])
 }

--- a/Test/triggers/let-expressions.dfy.expect
+++ b/Test/triggers/let-expressions.dfy.expect
@@ -1,4 +1,6 @@
 let-expressions.dfy(6,8): Info: Selected triggers: {s[i]}
 let-expressions.dfy(7,8): Info: Selected triggers: {s[i]}
+let-expressions.dfy(8,8): Info: Selected triggers: {s[_t#0], s[i]}
+let-expressions.dfy(9,8): Info: Selected triggers: {s[_t#0], s[i]}
 
 Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/triggers/let-expressions.dfy.expect
+++ b/Test/triggers/let-expressions.dfy.expect
@@ -1,3 +1,4 @@
-let-expressions.dfy(6,4): Info: Selected triggers: {s[i]}
+let-expressions.dfy(6,8): Info: Selected triggers: {s[i]}
+let-expressions.dfy(7,8): Info: Selected triggers: {s[i]}
 
 Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/triggers/let-expressions.dfy.expect
+++ b/Test/triggers/let-expressions.dfy.expect
@@ -1,0 +1,3 @@
+let-expressions.dfy(6,4): Info: Selected triggers: {s[i]}
+
+Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/triggers/loop-detection-is-not-too-strict.dfy
+++ b/Test/triggers/loop-detection-is-not-too-strict.dfy
@@ -35,6 +35,7 @@ method Test(z: int) {
   // Sanity check:
   assert forall x :: true || Q(x) || Q(if z > 1 then x else 3 * z + 1);
 
-  // WISH: It might also be good to zeta-reduce before loop detection.
+  // Let expressions are inlined before loop detection, causing this to get
+  // correctly rewritten.
   assert forall x :: true || Q(x) || (var xx := x+1; Q(xx));
 }

--- a/Test/triggers/loop-detection-is-not-too-strict.dfy.expect
+++ b/Test/triggers/loop-detection-is-not-too-strict.dfy.expect
@@ -10,6 +10,6 @@ loop-detection-is-not-too-strict.dfy(28,9): Info: Selected triggers:
 loop-detection-is-not-too-strict.dfy(33,9): Info: Selected triggers: {Q(x)}
 loop-detection-is-not-too-strict.dfy(34,9): Info: Selected triggers: {Q(x)}
 loop-detection-is-not-too-strict.dfy(36,9): Info: Selected triggers: {Q(_t#0), Q(x)}
-loop-detection-is-not-too-strict.dfy(39,9): Info: Selected triggers: {Q(_t#0), Q(x)}
+loop-detection-is-not-too-strict.dfy(40,9): Info: Selected triggers: {Q(_t#0), Q(x)}
 
 Dafny program verifier finished with 1 verified, 0 errors

--- a/Test/triggers/loop-detection-is-not-too-strict.dfy.expect
+++ b/Test/triggers/loop-detection-is-not-too-strict.dfy.expect
@@ -10,6 +10,6 @@ loop-detection-is-not-too-strict.dfy(28,9): Info: Selected triggers:
 loop-detection-is-not-too-strict.dfy(33,9): Info: Selected triggers: {Q(x)}
 loop-detection-is-not-too-strict.dfy(34,9): Info: Selected triggers: {Q(x)}
 loop-detection-is-not-too-strict.dfy(36,9): Info: Selected triggers: {Q(_t#0), Q(x)}
-loop-detection-is-not-too-strict.dfy(39,9): Info: Selected triggers: {Q(x)}
+loop-detection-is-not-too-strict.dfy(39,9): Info: Selected triggers: {Q(_t#0), Q(x)}
 
 Dafny program verifier finished with 1 verified, 0 errors


### PR DESCRIPTION
Fixes #128.

When TriggerAnnotation.Annotate encounters a LetExpr, it now inlines the let using Translator.Substitute (which is now static to make it easy to call from outside the translator).

This improves trigger selection when there are lets inside a quantifier. There was even an (admittedly synthetic) existing test case in the test suite that ran into this problem!

Note that the inlined expression is only considered for the purposes of trigger selection. The rest of the pipeline continues to see the un-inlined expression.

I considered factoring Translator.Substitute out of the translator and into its own file (or into Cloner), but in the end I felt that it made sense to leave it there because of the scary comment about dropping parts of expressions that are only for well-formedness checks. 