### PR TITLE
Support pattern matching on LHS of LetStmt

### DIFF
--- a/Source/Dafny/Cloner.cs
+++ b/Source/Dafny/Cloner.cs
@@ -624,7 +624,7 @@ namespace Microsoft.Dafny
 
       } else if (stmt is LetStmt) {
         var s = (LetStmt) stmt;
-        r = new LetStmt(Tok(s.Tok), Tok(s.EndTok), s.LHSs.ConvertAll(CloneCasePattern), s.RHSs.ConvertAll(CloneExpr));
+        r = new LetStmt(Tok(s.Tok), Tok(s.EndTok), CloneCasePattern(s.LHS), CloneExpr(s.RHS));
 
       } else if (stmt is ModifyStmt) {
         var s = (ModifyStmt)stmt;

--- a/Source/Dafny/Compiler.cs
+++ b/Source/Dafny/Compiler.cs
@@ -2028,11 +2028,8 @@ namespace Microsoft.Dafny {
 
       } else if (stmt is LetStmt) {
         var s = (LetStmt)stmt;
-        for (int i = 0; i < s.LHSs.Count; i++) {
-          var lhs = s.LHSs[i];
-          if (Contract.Exists(lhs.Vars, bv => !bv.IsGhost)) {
-            TrCasePatternOpt(lhs, s.RHSs[i], null, indent, wr, false);
-          }
+        if (Contract.Exists(s.LHS.Vars, bv => !bv.IsGhost)) {
+          TrCasePatternOpt(s.LHS, s.RHS, null, indent, wr, false);
         }
       } else if (stmt is ModifyStmt) {
         var s = (ModifyStmt)stmt;

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -391,8 +391,17 @@ bool IsLambda(bool allowLambda)
 }
 
 bool IsIdentParen() {
+  scanner.ResetPeek();
   Token x = scanner.Peek();
   return la.kind == _ident && x.kind == _openparen;
+}
+
+/* Used to disambiguate the LHS of a VarDeclStmt. If it looks like the start of a CasePattern,
+ * we consider it to be a LetStmt. But if we are looking at a simple identifier, then we
+ * consider it to be a VarDeclStmt.
+ */
+bool IsLetStmt() {
+  return IsIdentParen() || la.kind == _openparen;
 }
 
 bool IsIdentColonOrBar() {
@@ -2110,7 +2119,8 @@ VarDeclStatement<.out Statement/*!*/ s.>
   [ "ghost"                                 (. isGhost = true;  x = t; .)
   ]
   "var"                                     (. if (!isGhost) { x = t; } .)
-  ( { Attribute<ref attrs> }
+  ( IF(!IsLetStmt())
+    { Attribute<ref attrs> }
     LocalIdentTypeOptional<out d, isGhost>    (. lhss.Add(d); d.Attributes = attrs; attrs = null; .)
     { ","
       { Attribute<ref attrs> }
@@ -2146,21 +2156,11 @@ VarDeclStatement<.out Statement/*!*/ s.>
        }
        s = new VarDeclStmt(x, endTok, lhss, update);
     .)
-  | "("                             (. List<CasePattern> arguments = new List<CasePattern>();
-                                       CasePattern pat;
-                                       Expression e = dummyExpr;
-                                       IToken id = t;
-                                    .)
-      [ CasePattern<out pat>            (. arguments.Add(pat); .)
-        { "," CasePattern<out pat>      (. arguments.Add(pat); .)
-        }
-      ]
-    ")"                             (. // Parse parenthesis without an identifier as a built in tuple type.
-                                       theBuiltIns.TupleType(id, arguments.Count, true); // make sure the tuple type exists
-                                       string ctor = BuiltIns.TupleTypeCtorNamePrefix + arguments.Count;  //use the TupleTypeCtors
-                                       pat = new CasePattern(id, ctor, arguments); 
-                                       if (isGhost) { pat.Vars.Iter(bv => bv.IsGhost = true); }
-                                    .)
+  | (. CasePattern pat;
+       Expression e = dummyExpr;
+       IToken id = t;
+     .)
+     CasePattern<out pat> (. if (isGhost) { pat.Vars.Iter(bv => bv.IsGhost = true); } .)
     ( ":="
     | { Attribute<ref attrs> }
       ":|"                          (.  SemErr(pat.tok, "LHS of assign-such-that expression must be variables, not general patterns"); .)

--- a/Source/Dafny/Dafny.atg
+++ b/Source/Dafny/Dafny.atg
@@ -2146,9 +2146,7 @@ VarDeclStatement<.out Statement/*!*/ s.>
        }
        s = new VarDeclStmt(x, endTok, lhss, update);
     .)
-  | "("                             (. var letLHSs = new List<CasePattern>();
-                                       var letRHSs = new List<Expression>();
-                                       List<CasePattern> arguments = new List<CasePattern>();
+  | "("                             (. List<CasePattern> arguments = new List<CasePattern>();
                                        CasePattern pat;
                                        Expression e = dummyExpr;
                                        IToken id = t;
@@ -2162,16 +2160,15 @@ VarDeclStatement<.out Statement/*!*/ s.>
                                        string ctor = BuiltIns.TupleTypeCtorNamePrefix + arguments.Count;  //use the TupleTypeCtors
                                        pat = new CasePattern(id, ctor, arguments); 
                                        if (isGhost) { pat.Vars.Iter(bv => bv.IsGhost = true); }
-                                       letLHSs.Add(pat);
                                     .)
     ( ":="
     | { Attribute<ref attrs> }
       ":|"                          (.  SemErr(pat.tok, "LHS of assign-such-that expression must be variables, not general patterns"); .)
     )
-    Expression<out e, false, true>        (. letRHSs.Add(e); .)
+    Expression<out e, false, true>
     
     ";"
-    (. s = new LetStmt(e.tok, e.tok, letLHSs, letRHSs); .)
+    (. s = new LetStmt(e.tok, e.tok, pat, e); .)
   )
   .
 IfStmt<out Statement/*!*/ ifStmt>

--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -5829,13 +5829,13 @@ namespace Microsoft.Dafny {
 
   public class LetStmt : Statement 
   {
-    public readonly List<CasePattern> LHSs;
-    public readonly List<Expression> RHSs;
+    public readonly CasePattern LHS;
+    public readonly Expression RHS;
 
-    public LetStmt(IToken tok, IToken endTok, List<CasePattern> lhss, List<Expression> rhss)
+    public LetStmt(IToken tok, IToken endTok, CasePattern lhs, Expression rhs)
       : base(tok, endTok) {
-      LHSs = lhss;
-      RHSs = rhss;
+      LHS = lhs;
+      RHS = rhs;
     }
 
     public override IEnumerable<Expression> SubExpressions {
@@ -5843,18 +5843,16 @@ namespace Microsoft.Dafny {
         foreach (var e in Attributes.SubExpressions(Attributes)) {
           yield return e;
         }
-        foreach (var rhs in RHSs) {
-          yield return rhs;
-        }
+        
+        yield return RHS;
+        
       }
     }
 
     public IEnumerable<BoundVar> BoundVars {
       get {
-        foreach (var lhs in LHSs) {
-          foreach (var bv in lhs.Vars) {
-            yield return bv;
-          }
+        foreach (var bv in LHS.Vars) {
+          yield return bv;
         }
       }
     }

--- a/Source/Dafny/Parser.cs
+++ b/Source/Dafny/Parser.cs
@@ -2940,8 +2940,6 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			
 		} else if (la.kind == 54) {
 			Get();
-			var letLHSs = new List<CasePattern>();
-			var letRHSs = new List<Expression>();
 			List<CasePattern> arguments = new List<CasePattern>();
 			CasePattern pat;
 			Expression e = dummyExpr;
@@ -2961,7 +2959,6 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			string ctor = BuiltIns.TupleTypeCtorNamePrefix + arguments.Count;  //use the TupleTypeCtors
 			pat = new CasePattern(id, ctor, arguments); 
 			if (isGhost) { pat.Vars.Iter(bv => bv.IsGhost = true); }
-			letLHSs.Add(pat);
 			
 			if (la.kind == 86) {
 				Get();
@@ -2973,9 +2970,8 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 				SemErr(pat.tok, "LHS of assign-such-that expression must be variables, not general patterns"); 
 			} else SynErr(209);
 			Expression(out e, false, true);
-			letRHSs.Add(e); 
 			Expect(30);
-			s = new LetStmt(e.tok, e.tok, letLHSs, letRHSs); 
+			s = new LetStmt(e.tok, e.tok, pat, e);
 		} else SynErr(210);
 	}
 

--- a/Source/Dafny/Parser.cs
+++ b/Source/Dafny/Parser.cs
@@ -474,8 +474,17 @@ bool IsLambda(bool allowLambda)
 }
 
 bool IsIdentParen() {
+  scanner.ResetPeek();
   Token x = scanner.Peek();
   return la.kind == _ident && x.kind == _openparen;
+}
+
+/* Used to disambiguate the LHS of a VarDeclStmt. If it looks like the start of a CasePattern,
+ * we consider it to be a LetStmt. But if we are looking at a simple identifier, then we
+ * consider it to be a VarDeclStmt.
+ */
+bool IsLetStmt() {
+  return IsIdentParen() || la.kind == _openparen;
 }
 
 bool IsIdentColonOrBar() {
@@ -2879,7 +2888,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 		}
 		Expect(84);
 		if (!isGhost) { x = t; } 
-		if (la.kind == 1 || la.kind == 50) {
+		if (!IsLetStmt()) {
 			while (la.kind == 50) {
 				Attribute(ref attrs);
 			}
@@ -2938,28 +2947,13 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			}
 			s = new VarDeclStmt(x, endTok, lhss, update);
 			
-		} else if (la.kind == 54) {
-			Get();
-			List<CasePattern> arguments = new List<CasePattern>();
+		} else if (la.kind == 1 || la.kind == 54) {
 			CasePattern pat;
 			Expression e = dummyExpr;
 			IToken id = t;
 			
-			if (la.kind == 1 || la.kind == 54) {
-				CasePattern(out pat);
-				arguments.Add(pat); 
-				while (la.kind == 23) {
-					Get();
-					CasePattern(out pat);
-					arguments.Add(pat); 
-				}
-			}
-			Expect(55);
-			theBuiltIns.TupleType(id, arguments.Count, true); // make sure the tuple type exists
-			string ctor = BuiltIns.TupleTypeCtorNamePrefix + arguments.Count;  //use the TupleTypeCtors
-			pat = new CasePattern(id, ctor, arguments); 
-			if (isGhost) { pat.Vars.Iter(bv => bv.IsGhost = true); }
-			
+			CasePattern(out pat);
+			if (isGhost) { pat.Vars.Iter(bv => bv.IsGhost = true); } 
 			if (la.kind == 86) {
 				Get();
 			} else if (la.kind == 26 || la.kind == 50) {
@@ -2971,7 +2965,7 @@ List<Expression> decreases, ref Attributes decAttrs, ref Attributes modAttrs, st
 			} else SynErr(209);
 			Expression(out e, false, true);
 			Expect(30);
-			s = new LetStmt(e.tok, e.tok, pat, e);
+			s = new LetStmt(e.tok, e.tok, pat, e); 
 		} else SynErr(210);
 	}
 

--- a/Source/Dafny/Printer.cs
+++ b/Source/Dafny/Printer.cs
@@ -1228,15 +1228,10 @@ Everything) {
 
       } else if (stmt is LetStmt) {
         var s = (LetStmt)stmt;
-        wr.Write("var");
-        string sep = "";
-        foreach (var lhs in s.LHSs) {
-          wr.Write(sep);
-          PrintCasePattern(lhs);
-          sep = ", ";
-        }
+        wr.Write("var ");
+        PrintCasePattern(s.LHS);
         wr.Write(" := ");
-        PrintExpressionList(s.RHSs, true);
+        PrintExpression(s.RHS, true);
         wr.WriteLine(";");
 
       } else if (stmt is SkeletonStatement) {

--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -9050,19 +9050,16 @@ namespace Microsoft.Dafny {
             builder.Add(TrAssumeCmd(bv.Tok, wh));
           }
         }
-        Contract.Assert(s.LHSs.Count == s.RHSs.Count);  // checked by resolution
         var varNameGen = CurrentIdGenerator.NestedFreshIdGenerator("let#");
-        for (int i = 0; i < s.LHSs.Count; i++) {
-          var pat = s.LHSs[i];
-          var rhs = s.RHSs[i];
-          var nm = varNameGen.FreshId(string.Format("#{0}#", i));
-          var r = new Bpl.LocalVariable(pat.tok, new Bpl.TypedIdent(pat.tok, nm, TrType(rhs.Type)));
-          locals.Add(r);
-          var rIe = new Bpl.IdentifierExpr(rhs.tok, r);
-          CheckWellformedWithResult(s.RHSs[i], new WFOptions(null, false, false), rIe, pat.Expr.Type, locals, builder, etran);
-          CheckCasePatternShape(pat, rIe, rhs.tok, pat.Expr.Type, builder);
-          builder.Add(TrAssumeCmd(pat.tok, Bpl.Expr.Eq(etran.TrExpr(pat.Expr), rIe)));
-        }
+        var pat = s.LHS;
+        var rhs = s.RHS;
+        var nm = varNameGen.FreshId(string.Format("#{0}#", 0));
+        var r = new Bpl.LocalVariable(pat.tok, new Bpl.TypedIdent(pat.tok, nm, TrType(rhs.Type)));
+        locals.Add(r);
+        var rIe = new Bpl.IdentifierExpr(rhs.tok, r);
+        CheckWellformedWithResult(rhs, new WFOptions(null, false, false), rIe, pat.Expr.Type, locals, builder, etran);
+        CheckCasePatternShape(pat, rIe, rhs.tok, pat.Expr.Type, builder);
+        builder.Add(TrAssumeCmd(pat.tok, Bpl.Expr.Eq(etran.TrExpr(pat.Expr), rIe)));
       } else {
         Contract.Assert(false); throw new cce.UnreachableException();  // unexpected statement
       }

--- a/Test/dafny4/git-issue129.dfy
+++ b/Test/dafny4/git-issue129.dfy
@@ -24,3 +24,13 @@ method BarPoint()
 {
     var Point(x, y) := FooPoint();
 }
+
+datatype Option<A> = Some(val: A) | None
+
+method UseOption()
+{
+    var x := Some(3);
+    var Some(n) := x;
+    x := None;
+    var Some(m) := x;  // error: RHS is not certain to look like the pattern 'Some'
+}

--- a/Test/dafny4/git-issue129.dfy
+++ b/Test/dafny4/git-issue129.dfy
@@ -1,0 +1,26 @@
+// RUN: %dafny /compile:0 "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+function method Foo(): (int, int)
+{
+    (1, 2)
+}
+
+method Bar()
+    ensures var (x, y) := Foo(); x < y
+{
+    var (x, y) := Foo();
+}
+
+datatype Point = Point(x: int, y: int)
+
+function method FooPoint(): Point
+{
+    Point(1, 2)
+}
+
+method BarPoint()
+    ensures var Point(x, y) := FooPoint(); x < y
+{
+    var Point(x, y) := FooPoint();
+}

--- a/Test/dafny4/git-issue129.dfy.expect
+++ b/Test/dafny4/git-issue129.dfy.expect
@@ -1,0 +1,2 @@
+
+Dafny program verifier finished with 2 verified, 0 errors

--- a/Test/dafny4/git-issue129.dfy.expect
+++ b/Test/dafny4/git-issue129.dfy.expect
@@ -1,2 +1,5 @@
+git-issue129.dfy(35,8): Error: RHS is not certain to look like the pattern 'Some'
+Execution trace:
+    (0,0): anon0
 
-Dafny program verifier finished with 2 verified, 0 errors
+Dafny program verifier finished with 2 verified, 1 error


### PR DESCRIPTION
Fixes #129.

This PR allows arbitrary case patterns to appear on the LHS of a LetStmt. See #129 for an example.

There is a parsing ambiguity when the LHS is a simple identifier not followed by parens, which we resolve by choosing VarDeclStatement over LetStmt.