### PR TITLE
Checking only if "Dafny.exe" file can be found

### DIFF
--- a/Binaries/dafny
+++ b/Binaries/dafny
@@ -8,7 +8,7 @@ if [[ ! -x "$MONO" ]]; then
     exit 1
 fi
 
-if [[ ! -x "$DAFNY" ]]; then
+if [[ ! -e "$DAFNY" ]]; then
     echo "Error: Dafny.exe not found at $DAFNY."
     exit 1
 fi


### PR DESCRIPTION
There's no need to check if the execute permission is granted on the "Dafny.exe" file because the execution is done through mono