### PR TITLE
Check type parameters when checking if types are equal

### DIFF
--- a/Source/Dafny/DafnyAst.cs
+++ b/Source/Dafny/DafnyAst.cs
@@ -1410,13 +1410,13 @@ namespace Microsoft.Dafny {
       } else if (a is BigOrdinalType) {
         return b is BigOrdinalType;
       } else if (a is SetType) {
-        return b is SetType && (a.IsISetType || !b.IsISetType);
+        return b is SetType && Equal_Improved(a.TypeArgs[0], b.TypeArgs[0]) && (a.IsISetType == b.IsISetType);
       } else if (a is SeqType) {
-        return b is SeqType;
+        return b is SeqType && Equal_Improved(a.TypeArgs[0], b.TypeArgs[0]);
       } else if (a is MultiSetType) {
-        return b is MultiSetType;
+        return b is MultiSetType && Equal_Improved(a.TypeArgs[0], b.TypeArgs[0]);
       } else if (a is MapType) {
-        return b is MapType && (a.IsIMapType || !b.IsIMapType);
+        return b is MapType && Equal_Improved(a.TypeArgs[0], b.TypeArgs[0]) && Equal_Improved(a.TypeArgs[1], b.TypeArgs[1]) && (a.IsIMapType == b.IsIMapType);
       } else if (a is ArrowType) {
         var asuper = (ArrowType)a;
         var asub = b as ArrowType;

--- a/Test/dafny4/git-issue161.dfy
+++ b/Test/dafny4/git-issue161.dfy
@@ -1,0 +1,14 @@
+// RUN: %dafny /compile:0  "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+datatype Expr0 = Var(val: string)
+               | Const(val: int)
+
+datatype Expr1 = Var(val: seq<string>)
+               | Const(val: seq<int>)
+
+datatype Expr2 = Var(val: iset<string>)
+               | Const(val: set<string>)
+
+datatype Expr3 = Var(val: set<string>)
+               | Const(val: iset<string>)

--- a/Test/dafny4/git-issue161.dfy.expect
+++ b/Test/dafny4/git-issue161.dfy.expect
@@ -1,0 +1,5 @@
+git-issue161.dfy(5,23): Error: shared destructors must have the same type, but 'val' has type 'string' in constructor 'Var' and type 'int' in constructor 'Const'
+git-issue161.dfy(8,23): Error: shared destructors must have the same type, but 'val' has type 'seq<string>' in constructor 'Var' and type 'seq<int>' in constructor 'Const'
+git-issue161.dfy(11,23): Error: shared destructors must have the same type, but 'val' has type 'iset<string>' in constructor 'Var' and type 'set<string>' in constructor 'Const'
+git-issue161.dfy(14,23): Error: shared destructors must have the same type, but 'val' has type 'set<string>' in constructor 'Var' and type 'iset<string>' in constructor 'Const'
+4 resolution/type errors detected in git-issue161.dfy


### PR DESCRIPTION
Previously two collection types were considered equal if they were the
same type of collection, even if they had different type parameters.
This caused a missing error message and compilation errors if two
datatype destructors shared a name.

Fixes #161 and passes the test suite.