### PR TITLE
Fixes for quantifiers + let-such-that expressions

### DIFF
--- a/Source/Dafny/Translator.cs
+++ b/Source/Dafny/Translator.cs
@@ -16971,7 +16971,10 @@ namespace Microsoft.Dafny {
             if (rhs == e.RHSs[0] && body == e.Body) {
               return e;
             }
-            var newLet = new SubstLetExpr(e.tok, e.LHSs, new List<Expression>{ rhs }, body, e.Exact, e, substMap, typeMap);
+            // keep copies of the substitution maps so we can reuse them at desugaring time
+            var newSubstMap = new Dictionary<IVariable, Expression>(substMap);
+            var newTypeMap = new Dictionary<TypeParameter, Type>(typeMap);
+            var newLet = new SubstLetExpr(e.tok, e.LHSs, new List<Expression>{ rhs }, body, e.Exact, e, newSubstMap, newTypeMap);
             newExpr = newLet;
           }
 

--- a/Source/Dafny/Triggers/TriggerExtensions.cs
+++ b/Source/Dafny/Triggers/TriggerExtensions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Dafny.Triggers {
 
   internal static class ExprExtensions {
     internal static bool IsInlineable(this LetExpr expr) {
-      return expr.LHSs.All(p => p.Var != null);
+      return expr.LHSs.All(p => p.Var != null) && expr.Exact;
     }
 
     internal static IEnumerable<Expression> AllSubExpressions(this Expression expr, bool wrapOld, bool strict, bool inlineLets = false) {

--- a/Source/Dafny/Triggers/TriggersCollector.cs
+++ b/Source/Dafny/Triggers/TriggersCollector.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Dafny.Triggers {
 
       if (expr is LetExpr) {
         var le = (LetExpr)expr;
-        if (le.LHSs.All(p => p.Var != null)) {
+        if (le.LHSs.All(p => p.Var != null) && le.Exact) {
           // Inline the let expression before doing trigger selection.
           annotation = Annotate(Translator.InlineLet(le));
         }

--- a/Test/dafny0/LetExpr.dfy
+++ b/Test/dafny0/LetExpr.dfy
@@ -200,6 +200,12 @@ class TrickySubstitution {
     g
   }
 
+  // let-such-thats inside quantifiers must have quantified vars substituted correctly
+  predicate F5(n: int)
+  {
+    forall i :: 0 < i < n ==> var j, k :| k <= j < i; k <= j < i
+  }
+
   method M(x: int)
     requires this.v + x == 3 && this.w == 2;
     modifies this;

--- a/Test/dafny0/LetExpr.dfy.expect
+++ b/Test/dafny0/LetExpr.dfy.expect
@@ -1,7 +1,7 @@
-LetExpr.dfy(334,18): Error: value does not satisfy the subset constraints of 'nat'
+LetExpr.dfy(340,18): Error: value does not satisfy the subset constraints of 'nat'
 Execution trace:
     (0,0): anon0
-LetExpr.dfy(338,13): Error: value does not satisfy the subset constraints of 'nat'
+LetExpr.dfy(344,13): Error: value does not satisfy the subset constraints of 'nat'
 Execution trace:
     (0,0): anon0
 LetExpr.dfy(109,22): Error: assertion violation
@@ -11,36 +11,37 @@ Execution trace:
 LetExpr.dfy(9,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
-LetExpr.dfy(254,18): Error: value does not satisfy the subset constraints of 'nat'
+LetExpr.dfy(260,18): Error: value does not satisfy the subset constraints of 'nat'
 Execution trace:
     (0,0): anon0
     (0,0): anon5_Then
-LetExpr.dfy(257,18): Error: value does not satisfy the subset constraints of 'nat'
+LetExpr.dfy(263,18): Error: value does not satisfy the subset constraints of 'nat'
 Execution trace:
     (0,0): anon0
     (0,0): anon6_Then
-LetExpr.dfy(259,23): Error: value does not satisfy the subset constraints of 'nat'
+LetExpr.dfy(265,23): Error: value does not satisfy the subset constraints of 'nat'
 Execution trace:
     (0,0): anon0
     (0,0): anon6_Else
-LetExpr.dfy(288,13): Error: RHS is not certain to look like the pattern 'Agnes'
+LetExpr.dfy(294,13): Error: RHS is not certain to look like the pattern 'Agnes'
 Execution trace:
     (0,0): anon0
     (0,0): anon3_Else
-LetExpr.dfy(305,41): Error: value does not satisfy the subset constraints of 'nat'
+LetExpr.dfy(311,41): Error: value does not satisfy the subset constraints of 'nat'
 Execution trace:
     (0,0): anon0
     (0,0): anon7_Else
-LetExpr.dfy(307,11): Error: assertion violation
+LetExpr.dfy(313,11): Error: assertion violation
 Execution trace:
     (0,0): anon0
     (0,0): anon7_Else
-LetExpr.dfy(317,11): Error: to be compilable, the value of a let-such-that expression must be uniquely determined
+LetExpr.dfy(323,11): Error: to be compilable, the value of a let-such-that expression must be uniquely determined
 Execution trace:
     (0,0): anon0
     (0,0): anon10_Then
 
-Dafny program verifier finished with 27 verified, 11 errors
-LetExpr.dfy.tmp.dprint.dfy(188,2): Warning: /!\ No terms found to trigger on.
+Dafny program verifier finished with 28 verified, 11 errors
+LetExpr.dfy.tmp.dprint.dfy(97,4): Warning: /!\ No terms found to trigger on.
+LetExpr.dfy.tmp.dprint.dfy(195,2): Warning: /!\ No terms found to trigger on.
 
 Dafny program verifier finished with 0 verified, 0 errors


### PR DESCRIPTION
Fix two bugs involving combining let-such-thats with quantifiers:

* When inlining lets during trigger selection, we need to check the let is exact (i.e., not a let-such that)
* After fixing that issue, a let-such-that within a quantifier generates invalid Boogie, because let desugaring reuses a (mutable) substitution map that has had the quantified variables removed