### PR TITLE
Inline let-expressions before collecting quantifiers for trigger selection

### DIFF
--- a/Source/Dafny/Triggers/QuantifiersCollector.cs
+++ b/Source/Dafny/Triggers/QuantifiersCollector.cs
@@ -45,7 +45,18 @@ namespace Microsoft.Dafny.Triggers {
         exprsInOldContext.Add(expr);
       }
 
-      return true;
+      bool shouldContinue = true;
+      if (expr is LetExpr) {
+        var le = (LetExpr)expr;
+        if (le.LHSs.All(p => p.Var != null) && le.Exact) {
+          // inline this let-expr and visit the resulting expression rather than continuing this visitor
+          var newExpr = Translator.InlineLet(le);
+          this.Visit(newExpr, inOldContext);
+          shouldContinue = false;
+        }
+      }
+
+      return shouldContinue;
     }
 
     protected override bool VisitOneStmt(Statement stmt, ref bool st) {

--- a/Test/dafny4/git-issue167.dfy
+++ b/Test/dafny4/git-issue167.dfy
@@ -1,0 +1,16 @@
+// RUN: %dafny /compile:0  "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+// The let bindings for each `p` must be inlined before trigger selection
+// on the nested map comprehension, otherwise the selected trigger will be
+// invalid
+
+function Rewrite(env: map<nat, nat>): map<nat, nat> {
+    var p := map n: nat | n in env :: n;
+    map n: nat | n in p :: n
+}
+
+function Rewrite2(strs: set<string>): map<string, string> {
+    var p := map s: string | s in strs :: s;
+    map s: string | s in p :: s
+}

--- a/Test/dafny4/git-issue167.dfy.expect
+++ b/Test/dafny4/git-issue167.dfy.expect
@@ -1,0 +1,4 @@
+git-issue167.dfy(10,4): Warning: /!\ No terms found to trigger on.
+git-issue167.dfy(15,4): Warning: /!\ No terms found to trigger on.
+
+Dafny program verifier finished with 0 verified, 0 errors


### PR DESCRIPTION
Let expressions can change trigger selections in undesirable ways. For example, this expression:

    var p := map n: nat | n in env :: n;
    map n: nat | n in p :: n

has `n in p` selected as a trigger, but if we manually inline `p` there is no trigger found. `n in p` isn't a valid trigger here, since `p` will get inlined into the trigger later.

To fix this, we (temporarily) inline all lets before collecting the set of quantifiers to select triggers for. In some sense this is the converse of #130 -- here we inline lets appearing *outside* a quantifier.

Fixes #167.