### PR TITLE
Fixed Go test errors in Windows

### DIFF
--- a/Test/lit.site.cfg
+++ b/Test/lit.site.cfg
@@ -56,6 +56,13 @@ config.environment['PYTHON_EXECUTABLE'] = getattr(config, 'python_executable', '
 if 'NODE_PATH' in os.environ:
     config.environment['NODE_PATH'] = os.environ['NODE_PATH']
 
+# Propagate 'GOCACHE' into lit's environment
+# Fixes error
+#   build cache is required, but could not be located: 
+#   GOCACHE is not defined and %LocalAppData% is not defined
+if 'GOCACHE' in os.environ:
+    config.environment['GOCACHE'] = os.environ['GOCACHE']
+
 # Check that the object root is known.
 if config.test_exec_root is None:
     lit_config.fatal('Could not determine execution root for tests!')


### PR DESCRIPTION
GOCACHE needs to be set and forwarded to lit's environment