### PR TITLE
Revert "Allow type variables in tuples"

### DIFF
--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -12560,10 +12560,8 @@ namespace Microsoft.Dafny
         foreach (Type typeArg in udt.TypeArgs) {
           var t = PartiallyResolveTypeForMemberSelection(me.tok, typeArg).NormalizeExpand() as UserDefinedType;
           if (t != null) {
-            var cls = t.ResolvedClass as DatatypeDecl;
-            if (cls != null) {
-              ctorsList.Add(datatypeCtors[cls]);
-            }
+            dtd = cce.NonNull((DatatypeDecl)t.ResolvedClass);
+            ctorsList.Add(datatypeCtors[dtd]);
           } else {
             ctorsList.Add(new Dictionary<string, DatatypeCtor>());
           }


### PR DESCRIPTION
This reverts commit d106ef85c90405206db0319e0ca7420b7cf972c0.

The change breaks wildcard matching, such that even simple
programs like

```
module Foo {
  datatype t = A
  function method f(x: t): bool {
    match x
      case _ => true
  }
}
```

fail.