### PR TITLE
Mul associativity axiom: add a guard to prevent matching loop

### DIFF
--- a/Binaries/DafnyPrelude.bpl
+++ b/Binaries/DafnyPrelude.bpl
@@ -1355,7 +1355,7 @@ axiom (forall x, y: int ::
 #if ARITH_MUL_ASSOC
 axiom (forall x, y, z: int ::
   { Mul(x, Mul(y, z)) }
-  Mul(x, Mul(y, z)) == Mul(Mul(x, y), z));
+  Mul(y, z) != 0 ==> Mul(x, Mul(y, z)) == Mul(Mul(x, y), z));
 #endif
 
 // -------------------------------------------------------------------------

--- a/Binaries/DafnyPrelude.bpl
+++ b/Binaries/DafnyPrelude.bpl
@@ -1355,7 +1355,7 @@ axiom (forall x, y: int ::
 #if ARITH_MUL_ASSOC
 axiom (forall x, y, z: int ::
   { Mul(x, Mul(y, z)) }
-  Mul(x, Mul(y, z)) == mul(mul(x, y), z));
+  Mul(x, Mul(y, z)) == Mul(Mul(x, y), z));
 #endif
 
 // -------------------------------------------------------------------------

--- a/Test/dafny4/git-issue250.dfy
+++ b/Test/dafny4/git-issue250.dfy
@@ -1,0 +1,15 @@
+// RUN: %dafny /arith:1 "%s" > "%t"
+// RUN: %dafny /arith:2 "%s" >> "%t"
+// RUN: %dafny /arith:3 "%s" >> "%t"
+// RUN: %dafny /arith:4 "%s" >> "%t"
+// RUN: %dafny /arith:5 "%s" >> "%t"
+// RUN: %dafny /arith:6 "%s" >> "%t"
+// RUN: %dafny /arith:7 "%s" >> "%t"
+// RUN: %dafny /arith:8 "%s" >> "%t"
+// RUN: %dafny /arith:9 "%s" >> "%t"
+// RUN: %dafny /arith:10 "%s" >> "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method Main() {
+    
+}

--- a/Test/dafny4/git-issue250.dfy.expect
+++ b/Test/dafny4/git-issue250.dfy.expect
@@ -1,0 +1,20 @@
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors
+
+Dafny program verifier finished with 0 verified, 0 errors


### PR DESCRIPTION
Dafny /arith:10 Test/dafny1/Cubes.dfy
gets stuck in a matching loop due to the associativity axiom.

Adding a guard, checking whether the second argument is non-zero prevents the rewrite and hence z3 entering the matching loop.