### PR TITLE
Unix path separator in 'otherFilenames' not passed on

### DIFF
--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -2179,7 +2179,13 @@ namespace Microsoft.Dafny
           string extension = Path.GetExtension(file);
           if (extension != null) { extension = extension.ToLower(); }
           if (extension == ".cs") {
-            sourceFiles[index++] = Path.Combine(Path.GetDirectoryName(file), Path.GetFileName(file));
+            var normalizedPath = Path.Combine(Path.GetDirectoryName(file), Path.GetFileName(file));
+            if (File.Exists(normalizedPath)) {
+              sourceFiles[index++] = normalizedPath;
+            } else {
+              outputWriter.WriteLine("Errors compiling program: Could not find {0}", file);
+              return false;
+            }
           }
         }
         crx.cr = provider.CompileAssemblyFromFile(cp, sourceFiles);

--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -2166,7 +2166,7 @@ namespace Microsoft.Dafny
           if (extension == ".cs") {
             numOtherSourceFiles++;
           } else if (extension == ".dll") {
-            cp.ReferencedAssemblies.Add(file);
+            cp.ReferencedAssemblies.Add(Path.Combine(Path.GetDirectoryName(file), Path.GetFileName(file)));
           }
         }
       }

--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -2179,7 +2179,7 @@ namespace Microsoft.Dafny
           string extension = Path.GetExtension(file);
           if (extension != null) { extension = extension.ToLower(); }
           if (extension == ".cs") {
-            sourceFiles[index++] = file;
+            sourceFiles[index++] = Path.Combine(Path.GetDirectoryName(file), Path.GetFileName(file));
           }
         }
         crx.cr = provider.CompileAssemblyFromFile(cp, sourceFiles);


### PR DESCRIPTION
This commit fixes the following issue:

In cygwin and I assume other systems with Unix path separators, when Dafny is called with an external C# source file in a subdirectory, the C# compiler would not be passed the correct path. It would assume the external C# file is in the current directory.

e.g. `Dafny.exe src/file.dfy src/file-extern.cs` would call the C# compiler with `file-extern.dfy` instead of `src/file-extern.cs`.