### PR TITLE
Axiomatization of SeqFromArray, HeapSucc, and frame condition

### DIFF
--- a/Binaries/DafnyPrelude.bpl
+++ b/Binaries/DafnyPrelude.bpl
@@ -507,10 +507,9 @@ function {:inline} _System.real.Floor(x: real): int { Int(x) }
 // ---------------------------------------------------------------
 // -- The heap ---------------------------------------------------
 // ---------------------------------------------------------------
-
-type Heap = <alpha>[ref,Field alpha]alpha;
-function {:inline} read<alpha>(H:Heap, r:ref, f:Field alpha): alpha { H[r, f] }
-function {:inline} update<alpha>(H:Heap, r:ref, f:Field alpha, v:alpha): Heap { H[r,f := v] }
+type Heap = [ref]<alpha>[Field alpha]alpha;
+function {:inline} read<alpha>(H:Heap, r:ref, f:Field alpha): alpha { H[r][f] }
+function {:inline} update<alpha>(H:Heap, r:ref, f:Field alpha, v:alpha): Heap { H[r := H[r][f := v]] }
 
 function $IsGoodHeap(Heap): bool;
 function $IsHeapAnchor(Heap): bool;
@@ -527,7 +526,7 @@ axiom (forall<alpha> h: Heap, r: ref, f: Field alpha, x: alpha :: { update(h, r,
   $IsGoodHeap(update(h, r, f, x)) ==>
   $HeapSucc(h, update(h, r, f, x)));
 axiom (forall a,b,c: Heap :: { $HeapSucc(a,b), $HeapSucc(b,c) }
-  $HeapSucc(a,b) && $HeapSucc(b,c) ==> $HeapSucc(a,c));
+  a != c ==> $HeapSucc(a,b) && $HeapSucc(b,c) ==> $HeapSucc(a,c));
 axiom (forall h: Heap, k: Heap :: { $HeapSucc(h,k) }
   $HeapSucc(h,k) ==> (forall o: ref :: { read(k, o, alloc) } read(h, o, alloc) ==> read(k, o, alloc)));
 
@@ -1055,9 +1054,8 @@ axiom (forall h: Heap, a: ref ::
     Seq#Index(Seq#FromArray(h, a), i) == read(h, a, IndexField(i))));
 axiom (forall h0, h1: Heap, a: ref ::
   { Seq#FromArray(h1, a), $HeapSucc(h0, h1) }
-  $IsGoodHeap(h0) && $IsGoodHeap(h1) && $HeapSucc(h0, h1) &&
-  (forall i: int ::
-    0 <= i && i < _System.array.Length(a) ==> read(h0, a, IndexField(i)) == read(h1, a, IndexField(i)))
+  $IsGoodHeap(h0) && $IsGoodHeap(h1) && $HeapSucc(h0, h1)
+  && h0[a] == h1[a]
   ==>
   Seq#FromArray(h0, a) == Seq#FromArray(h1, a));
 axiom (forall h: Heap, i: int, v: Box, a: ref ::

--- a/Binaries/DafnyPrelude.bpl
+++ b/Binaries/DafnyPrelude.bpl
@@ -1054,8 +1054,7 @@ axiom (forall h: Heap, a: ref ::
     Seq#Index(Seq#FromArray(h, a), i) == read(h, a, IndexField(i))));
 axiom (forall h0, h1: Heap, a: ref ::
   { Seq#FromArray(h1, a), $HeapSucc(h0, h1) }
-  $IsGoodHeap(h0) && $IsGoodHeap(h1) && $HeapSucc(h0, h1)
-  && h0[a] == h1[a]
+  $IsGoodHeap(h0) && $IsGoodHeap(h1) && $HeapSucc(h0, h1) && h0[a] == h1[a]
   ==>
   Seq#FromArray(h0, a) == Seq#FromArray(h1, a));
 axiom (forall h: Heap, i: int, v: Box, a: ref ::

--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -2179,7 +2179,13 @@ namespace Microsoft.Dafny
           string extension = Path.GetExtension(file);
           if (extension != null) { extension = extension.ToLower(); }
           if (extension == ".cs") {
-            sourceFiles[index++] = Path.Combine(Path.GetDirectoryName(file), Path.GetFileName(file));
+            var normalizedPath = Path.Combine(Path.GetDirectoryName(file), Path.GetFileName(file));
+            if (File.Exists(normalizedPath)) {
+              sourceFiles[index++] = normalizedPath;
+            } else {
+              outputWriter.WriteLine("Errors compiling program: Could not find {0}", file);
+              return false;
+            }
           }
         }
         crx.cr = provider.CompileAssemblyFromFile(cp, sourceFiles);

--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -2166,7 +2166,7 @@ namespace Microsoft.Dafny
           if (extension == ".cs") {
             numOtherSourceFiles++;
           } else if (extension == ".dll") {
-            cp.ReferencedAssemblies.Add(file);
+            cp.ReferencedAssemblies.Add(Path.Combine(Path.GetDirectoryName(file), Path.GetFileName(file)));
           }
         }
       }

--- a/Source/Dafny/Compiler-Csharp.cs
+++ b/Source/Dafny/Compiler-Csharp.cs
@@ -2179,7 +2179,7 @@ namespace Microsoft.Dafny
           string extension = Path.GetExtension(file);
           if (extension != null) { extension = extension.ToLower(); }
           if (extension == ".cs") {
-            sourceFiles[index++] = file;
+            sourceFiles[index++] = Path.Combine(Path.GetDirectoryName(file), Path.GetFileName(file));
           }
         }
         crx.cr = provider.CompileAssemblyFromFile(cp, sourceFiles);

--- a/Test/dafny0/snapshots/Snapshots0.run.dfy.expect
+++ b/Test/dafny0/snapshots/Snapshots0.run.dfy.expect
@@ -5,7 +5,7 @@ Processing command (at Snapshots0.v0.dfy(4,10)) assert false;
 
 Dafny program verifier finished with 1 verified, 0 errors
 Processing call to procedure Call$$_module.__default.bar in implementation Impl$$_module.__default.foo (at Snapshots0.v1.dfy(3,6)):
-  >>> added axiom: (forall call0old#AT#$Heap: Heap, $Heap: Heap :: {:weight 30} { ##extracted_function##1(call0old#AT#$Heap, $Heap) } ##extracted_function##1(call0old#AT#$Heap, $Heap) == (true && Lit(false) && (forall<alpha> $o: ref, $f: Field alpha :: { read($Heap, $o, $f) } $o != null && read(call0old#AT#$Heap, $o, alloc) ==> read($Heap, $o, $f) == read(call0old#AT#$Heap, $o, $f)) && $HeapSucc(call0old#AT#$Heap, $Heap)))
+  >>> added axiom: (forall call0old#AT#$Heap: Heap, $Heap: Heap :: {:weight 30} { ##extracted_function##1(call0old#AT#$Heap, $Heap) } ##extracted_function##1(call0old#AT#$Heap, $Heap) == (true && Lit(false) && (forall<alpha> $o: ref, $f: Field alpha :: { read($Heap, $o, $f) } $o != null && read(call0old#AT#$Heap, $o, alloc) ==> read($Heap, $o, $f) == read(call0old#AT#$Heap, $o, $f)) && (forall $o: ref :: { $Heap[$o] } $o != null && read(call0old#AT#$Heap, $o, alloc) ==> $Heap[$o] == call0old#AT#$Heap[$o]) && $HeapSucc(call0old#AT#$Heap, $Heap)))
   >>> added after: a##cached##0 := a##cached##0 && ##extracted_function##1(call0old#AT#$Heap, $Heap);
 Processing command (at Snapshots0.v1.dfy(3,6)) assert (forall<alpha> $o: ref, $f: Field alpha :: false ==> $_Frame[$o, $f]);
   >>> MarkAsFullyVerified

--- a/Test/dafny0/snapshots/Snapshots0.run.dfy.expect
+++ b/Test/dafny0/snapshots/Snapshots0.run.dfy.expect
@@ -5,7 +5,7 @@ Processing command (at Snapshots0.v0.dfy(4,10)) assert false;
 
 Dafny program verifier finished with 1 verified, 0 errors
 Processing call to procedure Call$$_module.__default.bar in implementation Impl$$_module.__default.foo (at Snapshots0.v1.dfy(3,6)):
-  >>> added axiom: (forall call0old#AT#$Heap: Heap, $Heap: Heap :: {:weight 30} { ##extracted_function##1(call0old#AT#$Heap, $Heap) } ##extracted_function##1(call0old#AT#$Heap, $Heap) == (true && Lit(false) && (forall<alpha> $o: ref, $f: Field alpha :: { read($Heap, $o, $f) } $o != null && read(call0old#AT#$Heap, $o, alloc) ==> read($Heap, $o, $f) == read(call0old#AT#$Heap, $o, $f)) && (forall $o: ref :: { $Heap[$o] } $o != null && read(call0old#AT#$Heap, $o, alloc) ==> $Heap[$o] == call0old#AT#$Heap[$o]) && $HeapSucc(call0old#AT#$Heap, $Heap)))
+  >>> added axiom: (forall call0old#AT#$Heap: Heap, $Heap: Heap :: {:weight 30} { ##extracted_function##1(call0old#AT#$Heap, $Heap) } ##extracted_function##1(call0old#AT#$Heap, $Heap) == (true && Lit(false) && (forall $o: ref :: { $Heap[$o] } $o != null && read(call0old#AT#$Heap, $o, alloc) ==> $Heap[$o] == call0old#AT#$Heap[$o]) && $HeapSucc(call0old#AT#$Heap, $Heap)))
   >>> added after: a##cached##0 := a##cached##0 && ##extracted_function##1(call0old#AT#$Heap, $Heap);
 Processing command (at Snapshots0.v1.dfy(3,6)) assert (forall<alpha> $o: ref, $f: Field alpha :: false ==> $_Frame[$o, $f]);
   >>> MarkAsFullyVerified

--- a/Test/server/git-issue223.transcript.expect
+++ b/Test/server/git-issue223.transcript.expect
@@ -6,7 +6,7 @@ c:\DEV\Dafny\abs.dfy(4,4): Error BP5003: A postcondition might not hold on this 
 c:\DEV\Dafny\abs.dfy(3,10): Related location: This is the postcondition that might not hold.
 Execution trace:
     (0,0): anon0
-COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"((- 320))","Name":"x","RealName":null,"Value":"((- 320))"},{"CanonicalName":"(**y#0)","Name":"y","RealName":null,"Value":"(**y#0)"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"((- 320))","Name":"x","RealName":null,"Value":"((- 320))"},{"CanonicalName":"(**y#0)","Name":"y","RealName":null,"Value":"(**y#0)"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"((- 320))","Name":"x","RealName":null,"Value":"((- 320))"},{"CanonicalName":"((- 320))'1","Name":"y","RealName":null,"Value":"((- 320))'1"}]}]} COUNTEREXAMPLE_END
+COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"(**y#0)","Name":"y","RealName":null,"Value":"(**y#0)"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"(**y#0)","Name":"y","RealName":null,"Value":"(**y#0)"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"((- 1))'1","Name":"y","RealName":null,"Value":"((- 1))'1"}]}]} COUNTEREXAMPLE_END
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 
@@ -17,7 +17,7 @@ c:\DEV\Dafny\abs.dfy(4,4): Error BP5003: A postcondition might not hold on this 
 c:\DEV\Dafny\abs.dfy(3,10): Related location: This is the postcondition that might not hold.
 Execution trace:
     (0,0): anon0
-COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"((- 320))","Name":"x","RealName":null,"Value":"((- 320))"},{"CanonicalName":"(**y#0)","Name":"y","RealName":null,"Value":"(**y#0)"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"((- 320))","Name":"x","RealName":null,"Value":"((- 320))"},{"CanonicalName":"(**y#0)","Name":"y","RealName":null,"Value":"(**y#0)"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"((- 320))","Name":"x","RealName":null,"Value":"((- 320))"},{"CanonicalName":"((- 320))'1","Name":"y","RealName":null,"Value":"((- 320))'1"}]}]} COUNTEREXAMPLE_END
+COUNTEREXAMPLE_START {"States":[{"Column":0,"Line":0,"Name":"<initial>","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"(**y#0)","Name":"y","RealName":null,"Value":"(**y#0)"}]},{"Column":15,"Line":3,"Name":"c:\\DEV\\Dafny\\abs.dfy(3,15): initial state","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"(**y#0)","Name":"y","RealName":null,"Value":"(**y#0)"}]},{"Column":12,"Line":4,"Name":"c:\\DEV\\Dafny\\abs.dfy(4,12)","Variables":[{"CanonicalName":"((- 1))","Name":"x","RealName":null,"Value":"((- 1))"},{"CanonicalName":"((- 1))'1","Name":"y","RealName":null,"Value":"((- 1))'1"}]}]} COUNTEREXAMPLE_END
 Verification completed successfully!
 [SUCCESS] [[DAFNY-SERVER: EOM]]
 Verification completed successfully!


### PR DESCRIPTION
Fixed a performance issue by changing the antecedent of the axiom, preserving equality of `SeqFromArray` through `HeapSucc`, to check equality of the heap on object instead of field granularity.
This is possible after changing the Heap's type from `type Heap = <alpha>[ref,Field alpha]alpha;` to `type Heap = [ref]<alpha>[Field alpha]alpha;`---i.e., currying.
This required to change the frame condition.
Some test cases had to be updated to reflect changes to the counterexamples or output messages.

Also changed the `HeapSucc` transitivity axiom to exclude cycles, to prevent matching loops.

Test suite after the change sorted by absolute runtime change (positive numbers are slowdowns, negative speedups), compared to master on June 6: https://gist.github.com/mschlaipfer/03814aeacfdc6c4cfe4a74cf09c6d51a (not sure which commit hash, will use commit hashes in the future to compare)

Just noticed, that this PR also contains the changes proposed in PR #264