### PR TITLE
Fix type resolution for multi-indexing

### DIFF
--- a/Source/Dafny/Resolver.cs
+++ b/Source/Dafny/Resolver.cs
@@ -14703,11 +14703,13 @@ namespace Microsoft.Dafny
         AddXConstraint(e.tok, "MultiIndexable", e.Seq.Type, "multi-selection of elements requires a sequence or array (got {0})");
         if (e.E0 != null) {
           ResolveExpression(e.E0, opts);
-          ConstrainSubtypeRelation(NewIntegerBasedProxy(e.tok), e.E0.Type, e.E0, "multi-selection requires {0} indices (got {1})");
+          AddXConstraint(e.E0.tok, "ContainerIndex", e.Seq.Type, e.E0.Type, "incorrect type for selection into {0} (got {1})");
+          ConstrainSubtypeRelation(NewIntegerBasedProxy(e.tok), e.E0.Type, e.E0, "wrong number of indices for multi-selection");
         }
         if (e.E1 != null) {
           ResolveExpression(e.E1, opts);
-          ConstrainSubtypeRelation(NewIntegerBasedProxy(e.tok), e.E1.Type, e.E1, "multi-selection requires {0} indices (got {1})");
+          AddXConstraint(e.E1.tok, "ContainerIndex", e.Seq.Type, e.E1.Type, "incorrect type for selection into {0} (got {1})");
+          ConstrainSubtypeRelation(NewIntegerBasedProxy(e.tok), e.E1.Type, e.E1, "wrong number of indices for multi-selection");
         }
         var resultType = new InferredTypeProxy() { KeepConstraints = true };
         e.Type = new SeqType(resultType);

--- a/Test/git-issues/git-issue-277.dfy
+++ b/Test/git-issues/git-issue-277.dfy
@@ -1,0 +1,6 @@
+// RUN: %dafny /compile:3 /optimize /print:"%t.print" /dprint:"%t.dprint" "%s" > "%t"
+// RUN: %diff "%s.expect" "%t"
+
+method m(a : array<int>) {
+	assert a[..true] == a[..true];
+}

--- a/Test/git-issues/git-issue-277.dfy.expect
+++ b/Test/git-issues/git-issue-277.dfy.expect
@@ -1,0 +1,5 @@
+git-issue-277.dfy(5,12): Error: wrong number of indices for multi-selection
+git-issue-277.dfy(5,25): Error: wrong number of indices for multi-selection
+git-issue-277.dfy(5,12): Error: incorrect type for selection into array<int> (got bool)
+git-issue-277.dfy(5,25): Error: incorrect type for selection into array<int> (got bool)
+4 resolution/type errors detected in git-issue-277.dfy


### PR DESCRIPTION
Fixes #277. There were two errors: typechecking did not occur for indices of slices, and there was a formatting error when calling ConstrainSubtypeRelation.
